### PR TITLE
Set rails_event_store version number

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.5.3'
 
 gem 'rails', '~> 5.2.4'
-gem 'rails_event_store'
+gem 'rails_event_store', '0.37.0'
 gem 'kaminari'
 
 gem 'mysql2'


### PR DESCRIPTION
Fixes issue: https://github.com/RailsEventStore/rails_event_store/issues/713 by bumping version down to "0.37.0"

in https://github.com/assist-software/rails-eventstore-entities-tracker/blob/master/lib/command_handlers/entities/create_entity.rb#L14